### PR TITLE
Do not drop exceptions in collection getDocument

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+- fixed silently dropping exceptions on collection getDocument calls
+
 ## [5.0.4] - 2019-18-01
 
 ### Fixed

--- a/src/main/java/com/arangodb/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionAsyncImpl.java
@@ -129,7 +129,23 @@ public class ArangoCollectionAsyncImpl
 		DocumentUtil.validateDocumentKey(key);
 		final CompletableFuture<T> result = new CompletableFuture<>();
 		final CompletableFuture<T> execute = executor.execute(getDocumentRequest(key, new DocumentReadOptions()), type);
-		execute.whenComplete((response, ex) -> result.complete(response));
+		execute.whenComplete((response, ex) -> {
+			if (ex == null) {
+				result.complete(response);
+			} else if (ex instanceof ArangoDBException) {
+				ArangoDBException aex = (ArangoDBException) ex;
+
+				if ((aex.getResponseCode() == null && "com.arangodb.ArangoDBException: Response Code: 304".equals(ex.toString()))
+						|| (aex.getResponseCode() != null && aex.getResponseCode() == 404 && aex.getErrorNum() == 1202)
+						|| (aex.getResponseCode() != null && aex.getResponseCode() == 412 && aex.getErrorNum() == 1200)) {
+					result.complete(response);
+				} else {
+					result.completeExceptionally(ex);
+				}
+			} else {
+				result.completeExceptionally(ex);
+			}
+		});
 		return result;
 	}
 
@@ -141,7 +157,23 @@ public class ArangoCollectionAsyncImpl
 		DocumentUtil.validateDocumentKey(key);
 		final CompletableFuture<T> result = new CompletableFuture<>();
 		final CompletableFuture<T> execute = executor.execute(getDocumentRequest(key, options), type);
-		execute.whenComplete((response, ex) -> result.complete(response));
+		execute.whenComplete((response, ex) -> {
+			if (ex == null) {
+				result.complete(response);
+			} else if (ex instanceof ArangoDBException) {
+				ArangoDBException aex = (ArangoDBException) ex;
+
+				if ((aex.getResponseCode() == null && "com.arangodb.ArangoDBException: Response Code: 304".equals(ex.toString()))
+						|| (aex.getResponseCode() != null && aex.getResponseCode() == 404 && aex.getErrorNum() == 1202)
+						|| (aex.getResponseCode() != null && aex.getResponseCode() == 412 && aex.getErrorNum() == 1200)) {
+					result.complete(response);
+				} else {
+					result.completeExceptionally(ex);
+				}
+			} else {
+				result.completeExceptionally(ex);
+			}
+		});
 		return result;
 	}
 


### PR DESCRIPTION
This is a draft pull request to fix issue #16. See my line notes on the pull.