### PR TITLE
Bugfix/synchronous exceptions

### DIFF
--- a/src/main/java/com/arangodb/ArangoCollectionAsync.java
+++ b/src/main/java/com/arangodb/ArangoCollectionAsync.java
@@ -131,7 +131,6 @@ public interface ArangoCollectionAsync extends ArangoSerializationAccessor {
 	 * @param values
 	 *            a list of Objects that will be stored as documents
 	 * @return information about the import
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<DocumentImportEntity> importDocuments(final Collection<?> values);
 
@@ -143,7 +142,6 @@ public interface ArangoCollectionAsync extends ArangoSerializationAccessor {
 	 * @param options
 	 *            Additional options, can be null
 	 * @return information about the import
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<DocumentImportEntity> importDocuments(
 		final Collection<?> values,
@@ -155,7 +153,6 @@ public interface ArangoCollectionAsync extends ArangoSerializationAccessor {
 	 * @param values
 	 *            JSON-encoded array of objects that will be stored as documents
 	 * @return information about the import
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<DocumentImportEntity> importDocuments(final String values);
 
@@ -167,7 +164,6 @@ public interface ArangoCollectionAsync extends ArangoSerializationAccessor {
 	 * @param options
 	 *            Additional options, can be null
 	 * @return information about the import
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<DocumentImportEntity> importDocuments(final String values, final DocumentImportOptions options);
 
@@ -740,5 +736,5 @@ public interface ArangoCollectionAsync extends ArangoSerializationAccessor {
 	 * @return permissions of the user
 	 * @since ArangoDB 3.2.0
 	 */
-	CompletableFuture<Permissions> getPermissions(final String user) throws ArangoDBException;
+	CompletableFuture<Permissions> getPermissions(final String user);
 }

--- a/src/main/java/com/arangodb/ArangoDBAsync.java
+++ b/src/main/java/com/arangodb/ArangoDBAsync.java
@@ -655,7 +655,6 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
 	 * @param user
 	 *            The name of the user for which you want to query the databases
 	 * @return
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<Collection<String>> getAccessibleDatabasesFor(final String user);
 
@@ -672,7 +671,6 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
 	 * Returns the server role.
 	 * 
 	 * @return the server role
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<ServerRole> getRole();
 
@@ -772,8 +770,7 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
 	 * @since ArangoDB 3.2.0
 	 * @return void
 	 */
-	CompletableFuture<Void> grantDefaultDatabaseAccess(final String user, final Permissions permissions)
-			throws ArangoDBException;
+	CompletableFuture<Void> grantDefaultDatabaseAccess(final String user, final Permissions permissions);
 
 	/**
 	 * Sets the default access level for collections for the user <code>user</code>. You need permission to the _system
@@ -786,8 +783,7 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
 	 * @since ArangoDB 3.2.0
 	 * @return void
 	 */
-	CompletableFuture<Void> grantDefaultCollectionAccess(final String user, final Permissions permissions)
-			throws ArangoDBException;
+	CompletableFuture<Void> grantDefaultCollectionAccess(final String user, final Permissions permissions);
 
 	/**
 	 * Generic Execute. Use this method to execute custom FOXX services.
@@ -795,7 +791,6 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
 	 * @param request
 	 *            VelocyStream request
 	 * @return VelocyStream response
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<Response> execute(final Request request);
 
@@ -815,7 +810,6 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
 	 * Returns the server's current loglevel settings.
 	 * 
 	 * @return the server's current loglevel settings
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<LogLevelEntity> getLogLevel();
 
@@ -825,7 +819,6 @@ public interface ArangoDBAsync extends ArangoSerializationAccessor {
 	 * @param entity
 	 *            loglevel settings
 	 * @return the server's current loglevel settings
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<LogLevelEntity> setLogLevel(final LogLevelEntity entity);
 }

--- a/src/main/java/com/arangodb/ArangoDatabaseAsync.java
+++ b/src/main/java/com/arangodb/ArangoDatabaseAsync.java
@@ -254,10 +254,8 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 * @param permissions
 	 *            The permissions the user grant
 	 * @since ArangoDB 3.2.0
-	 * @throws ArangoDBException
 	 */
-	CompletableFuture<Void> grantDefaultCollectionAccess(final String user, final Permissions permissions)
-			throws ArangoDBException;
+	CompletableFuture<Void> grantDefaultCollectionAccess(final String user, final Permissions permissions);
 
 	/**
 	 * Get specific database access level
@@ -269,7 +267,7 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 * @return permissions of the user
 	 * @since ArangoDB 3.2.0
 	 */
-	CompletableFuture<Permissions> getPermissions(final String user) throws ArangoDBException;
+	CompletableFuture<Permissions> getPermissions(final String user);
 
 	/**
 	 * Performs a database query using the given {@code query} and {@code bindVars}, then returns a new
@@ -286,13 +284,12 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 * @param type
 	 *            The type of the result (POJO class, VPackSlice, String for Json, or Collection/List/Map)
 	 * @return cursor of the results
-	 * @throws ArangoDBException
 	 */
 	<T> CompletableFuture<ArangoCursorAsync<T>> query(
 		final String query,
 		final Map<String, Object> bindVars,
 		final AqlQueryOptions options,
-		final Class<T> type) throws ArangoDBException;
+		final Class<T> type);
 
 	/**
 	 * Performs a database query using the given {@code query}, then returns a new {@code ArangoCursor} instance for the
@@ -307,12 +304,11 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 * @param type
 	 *            The type of the result (POJO class, VPackSlice, String for Json, or Collection/List/Map)
 	 * @return cursor of the results
-	 * @throws ArangoDBException
 	 */
 	<T> CompletableFuture<ArangoCursorAsync<T>> query(
 		final String query,
 		final AqlQueryOptions options,
-		final Class<T> type) throws ArangoDBException;
+		final Class<T> type);
 
 	/**
 	 * Performs a database query using the given {@code query} and {@code bindVars}, then returns a new
@@ -327,12 +323,11 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 * @param type
 	 *            The type of the result (POJO class, VPackSlice, String for Json, or Collection/List/Map)
 	 * @return cursor of the results
-	 * @throws ArangoDBException
 	 */
 	<T> CompletableFuture<ArangoCursorAsync<T>> query(
 		final String query,
 		final Map<String, Object> bindVars,
-		final Class<T> type) throws ArangoDBException;
+		final Class<T> type);
 
 	/**
 	 * Performs a database query using the given {@code query}, then returns a new {@code ArangoCursor} instance for the
@@ -345,9 +340,8 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 * @param type
 	 *            The type of the result (POJO class, VPackSlice, String for Json, or Collection/List/Map)
 	 * @return cursor of the results
-	 * @throws ArangoDBException
 	 */
-	<T> CompletableFuture<ArangoCursorAsync<T>> query(final String query, final Class<T> type) throws ArangoDBException;
+	<T> CompletableFuture<ArangoCursorAsync<T>> query(final String query, final Class<T> type);
 
 	/**
 	 * Return an cursor from the given cursor-ID if still existing
@@ -360,10 +354,8 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 * @param type
 	 *            The type of the result (POJO class, VPackSlice, String for Json, or Collection/List/Map)
 	 * @return cursor of the results
-	 * @throws ArangoDBException
 	 */
-	<T> CompletableFuture<ArangoCursorAsync<T>> cursor(final String cursorId, final Class<T> type)
-			throws ArangoDBException;
+	<T> CompletableFuture<ArangoCursorAsync<T>> cursor(final String cursorId, final Class<T> type);
 
 	/**
 	 * Explain an AQL query and return information about it
@@ -684,10 +676,9 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 * 
 	 * @see <a href="https://docs.arangodb.com/current/HTTP/Views/Getting.html#reads-all-views">API Documentation</a>
 	 * @return list of information about all views
-	 * @throws ArangoDBException
 	 * @since ArangoDB 3.4.0
 	 */
-	CompletableFuture<Collection<ViewEntity>> getViews() throws ArangoDBException;
+	CompletableFuture<Collection<ViewEntity>> getViews();
 
 	/**
 	 * Returns a {@code ArangoViewAsync} instance for the given view name.
@@ -718,9 +709,8 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 *            The type of the view
 	 * @return information about the view
 	 * @since ArangoDB 3.4.0
-	 * @throws ArangoDBException
 	 */
-	CompletableFuture<ViewEntity> createView(String name, ViewType type) throws ArangoDBException;
+	CompletableFuture<ViewEntity> createView(String name, ViewType type);
 
 	/**
 	 * Creates a ArangoSearch view with the given {@code options}, then returns view information from the server.
@@ -733,9 +723,7 @@ public interface ArangoDatabaseAsync extends ArangoSerializationAccessor {
 	 *            Additional options, can be null
 	 * @return information about the view
 	 * @since ArangoDB 3.4.0
-	 * @throws ArangoDBException
 	 */
-	CompletableFuture<ViewEntity> createArangoSearch(String name, ArangoSearchCreateOptions options)
-			throws ArangoDBException;
+	CompletableFuture<ViewEntity> createArangoSearch(String name, ArangoSearchCreateOptions options);
 
 }

--- a/src/main/java/com/arangodb/ArangoVertexCollectionAsync.java
+++ b/src/main/java/com/arangodb/ArangoVertexCollectionAsync.java
@@ -154,9 +154,8 @@ public interface ArangoVertexCollectionAsync extends ArangoSerializationAccessor
 	 * @param type
 	 *            The type of the vertex-document (POJO class, VPackSlice or String for Json)
 	 * @return information about the vertex
-	 * @throws ArangoDBException
 	 */
-	<T> CompletableFuture<VertexUpdateEntity> updateVertex(final String key, final T value) throws ArangoDBException;
+	<T> CompletableFuture<VertexUpdateEntity> updateVertex(final String key, final T value);
 
 	/**
 	 * Partially updates the vertex identified by document-key. The value must contain a document with the attributes to
@@ -171,12 +170,11 @@ public interface ArangoVertexCollectionAsync extends ArangoSerializationAccessor
 	 * @param options
 	 *            Additional options, can be null
 	 * @return information about the vertex
-	 * @throws ArangoDBException
 	 */
 	<T> CompletableFuture<VertexUpdateEntity> updateVertex(
 		final String key,
 		final T value,
-		final VertexUpdateOptions options) throws ArangoDBException;
+		final VertexUpdateOptions options);
 
 	/**
 	 * Removes a vertex

--- a/src/main/java/com/arangodb/ArangoViewAsync.java
+++ b/src/main/java/com/arangodb/ArangoViewAsync.java
@@ -51,7 +51,6 @@ public interface ArangoViewAsync extends ArangoSerializationAccessor {
 	 * Checks whether the view exists.
 	 * 
 	 * @return true if the view exists, otherwise false
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<Boolean> exists();
 
@@ -59,7 +58,6 @@ public interface ArangoViewAsync extends ArangoSerializationAccessor {
 	 * Deletes the view from the database.
 	 * 
 	 * @see <a href= "https://docs.arangodb.com/current/HTTP/Views/Creating.html#drops-a-view">API Documentation</a>
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<Void> drop();
 
@@ -70,7 +68,6 @@ public interface ArangoViewAsync extends ArangoSerializationAccessor {
 	 * @param newName
 	 *            The new name
 	 * @return information about the view
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<ViewEntity> rename(String newName);
 
@@ -80,7 +77,6 @@ public interface ArangoViewAsync extends ArangoSerializationAccessor {
 	 * @see <a href= "https://docs.arangodb.com/current/HTTP/Views/Getting.html#return-information-about-a-view">API
 	 *      Documentation</a>
 	 * @return information about the view
-	 * @throws ArangoDBException
 	 */
 	CompletableFuture<ViewEntity> getInfo();
 

--- a/src/main/java/com/arangodb/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionAsyncImpl.java
@@ -426,7 +426,7 @@ public class ArangoCollectionAsyncImpl
 	}
 
 	@Override
-	public CompletableFuture<Permissions> getPermissions(final String user) throws ArangoDBException {
+	public CompletableFuture<Permissions> getPermissions(final String user) {
 		return executor.execute(getPermissionsRequest(user), getPermissionsResponseDeserialzer());
 	}
 }

--- a/src/main/java/com/arangodb/internal/ArangoCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoCollectionAsyncImpl.java
@@ -20,413 +20,382 @@
 
 package com.arangodb.internal;
 
-import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
-
 import com.arangodb.ArangoCollectionAsync;
 import com.arangodb.ArangoDBException;
-import com.arangodb.entity.CollectionEntity;
-import com.arangodb.entity.CollectionPropertiesEntity;
-import com.arangodb.entity.CollectionRevisionEntity;
-import com.arangodb.entity.DocumentCreateEntity;
-import com.arangodb.entity.DocumentDeleteEntity;
-import com.arangodb.entity.DocumentImportEntity;
-import com.arangodb.entity.DocumentUpdateEntity;
-import com.arangodb.entity.IndexEntity;
-import com.arangodb.entity.MultiDocumentEntity;
-import com.arangodb.entity.Permissions;
-import com.arangodb.internal.ArangoExecutor.ResponseDeserializer;
+import com.arangodb.entity.*;
 import com.arangodb.internal.util.DocumentUtil;
-import com.arangodb.model.CollectionCreateOptions;
-import com.arangodb.model.CollectionPropertiesOptions;
-import com.arangodb.model.DocumentCreateOptions;
-import com.arangodb.model.DocumentDeleteOptions;
-import com.arangodb.model.DocumentExistsOptions;
-import com.arangodb.model.DocumentImportOptions;
-import com.arangodb.model.DocumentReadOptions;
-import com.arangodb.model.DocumentReplaceOptions;
-import com.arangodb.model.DocumentUpdateOptions;
-import com.arangodb.model.FulltextIndexOptions;
-import com.arangodb.model.GeoIndexOptions;
-import com.arangodb.model.HashIndexOptions;
-import com.arangodb.model.PersistentIndexOptions;
-import com.arangodb.model.SkiplistIndexOptions;
-import com.arangodb.velocypack.exception.VPackException;
-import com.arangodb.velocystream.Response;
+import com.arangodb.model.*;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
 
 /**
  * @author Mark Vollmary
- *
  */
 public class ArangoCollectionAsyncImpl
-		extends InternalArangoCollection<ArangoDBAsyncImpl, ArangoDatabaseAsyncImpl, ArangoExecutorAsync>
-		implements ArangoCollectionAsync {
+        extends InternalArangoCollection<ArangoDBAsyncImpl, ArangoDatabaseAsyncImpl, ArangoExecutorAsync>
+        implements ArangoCollectionAsync {
 
-	protected ArangoCollectionAsyncImpl(final ArangoDatabaseAsyncImpl db, final String name) {
-		super(db, name);
-	}
+    protected ArangoCollectionAsyncImpl(final ArangoDatabaseAsyncImpl db, final String name) {
+        super(db, name);
+    }
 
-	@Override
-	public <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(final T value) {
-		final DocumentCreateOptions options = new DocumentCreateOptions();
-		return executor.execute(insertDocumentRequest(value, options),
-			insertDocumentResponseDeserializer(value, options));
-	}
+    @Override
+    public <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(final T value) {
+        final DocumentCreateOptions options = new DocumentCreateOptions();
+        return executor.execute(insertDocumentRequest(value, options),
+                insertDocumentResponseDeserializer(value, options));
+    }
 
-	@Override
-	public <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(
-		final T value,
-		final DocumentCreateOptions options) {
-		return executor.execute(insertDocumentRequest(value, options),
-			insertDocumentResponseDeserializer(value, options));
-	}
+    @Override
+    public <T> CompletableFuture<DocumentCreateEntity<T>> insertDocument(
+            final T value,
+            final DocumentCreateOptions options) {
+        return executor.execute(insertDocumentRequest(value, options),
+                insertDocumentResponseDeserializer(value, options));
+    }
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(
-		final Collection<T> values) {
-		final DocumentCreateOptions params = new DocumentCreateOptions();
-		return executor.execute(insertDocumentsRequest(values, params),
-			insertDocumentsResponseDeserializer(values, params));
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(
+            final Collection<T> values) {
+        final DocumentCreateOptions params = new DocumentCreateOptions();
+        return executor.execute(insertDocumentsRequest(values, params),
+                insertDocumentsResponseDeserializer(values, params));
+    }
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(
-		final Collection<T> values,
-		final DocumentCreateOptions options) {
-		final DocumentCreateOptions params = (options != null ? options : new DocumentCreateOptions());
-		return executor.execute(insertDocumentsRequest(values, params),
-			insertDocumentsResponseDeserializer(values, params));
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentCreateEntity<T>>> insertDocuments(
+            final Collection<T> values,
+            final DocumentCreateOptions options) {
+        final DocumentCreateOptions params = (options != null ? options : new DocumentCreateOptions());
+        return executor.execute(insertDocumentsRequest(values, params),
+                insertDocumentsResponseDeserializer(values, params));
+    }
 
-	@Override
-	public CompletableFuture<DocumentImportEntity> importDocuments(final Collection<?> values) {
-		return importDocuments(values, new DocumentImportOptions());
-	}
+    @Override
+    public CompletableFuture<DocumentImportEntity> importDocuments(final Collection<?> values) {
+        return importDocuments(values, new DocumentImportOptions());
+    }
 
-	@Override
-	public CompletableFuture<DocumentImportEntity> importDocuments(
-		final Collection<?> values,
-		final DocumentImportOptions options) {
-		return executor.execute(importDocumentsRequest(values, options), DocumentImportEntity.class);
-	}
+    @Override
+    public CompletableFuture<DocumentImportEntity> importDocuments(
+            final Collection<?> values,
+            final DocumentImportOptions options) {
+        return executor.execute(importDocumentsRequest(values, options), DocumentImportEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<DocumentImportEntity> importDocuments(final String values) {
-		return executor.execute(importDocumentsRequest(values, new DocumentImportOptions()),
-			DocumentImportEntity.class);
-	}
+    @Override
+    public CompletableFuture<DocumentImportEntity> importDocuments(final String values) {
+        return executor.execute(importDocumentsRequest(values, new DocumentImportOptions()),
+                DocumentImportEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<DocumentImportEntity> importDocuments(
-		final String values,
-		final DocumentImportOptions options) {
-		return executor.execute(importDocumentsRequest(values, options), DocumentImportEntity.class);
-	}
+    @Override
+    public CompletableFuture<DocumentImportEntity> importDocuments(
+            final String values,
+            final DocumentImportOptions options) {
+        return executor.execute(importDocumentsRequest(values, options), DocumentImportEntity.class);
+    }
 
-	@Override
-	public <T> CompletableFuture<T> getDocument(final String key, final Class<T> type) throws ArangoDBException {
-		DocumentUtil.validateDocumentKey(key);
-		final CompletableFuture<T> result = new CompletableFuture<>();
-		final CompletableFuture<T> execute = executor.execute(getDocumentRequest(key, new DocumentReadOptions()), type);
-		execute.whenComplete((response, ex) -> result.complete(response));
-		return result;
-	}
+    @Override
+    public <T> CompletableFuture<T> getDocument(final String key, final Class<T> type) throws ArangoDBException {
+        return getDocument(key, type, new DocumentReadOptions());
+    }
 
-	@Override
-	public <T> CompletableFuture<T> getDocument(
-		final String key,
-		final Class<T> type,
-		final DocumentReadOptions options) throws ArangoDBException {
-		DocumentUtil.validateDocumentKey(key);
-		final CompletableFuture<T> result = new CompletableFuture<>();
-		final CompletableFuture<T> execute = executor.execute(getDocumentRequest(key, options), type);
-		execute.whenComplete((response, ex) -> result.complete(response));
-		return result;
-	}
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> CompletableFuture<T> getDocument(
+            final String key,
+            final Class<T> type,
+            final DocumentReadOptions options) throws ArangoDBException {
+        DocumentUtil.validateDocumentKey(key);
+        return (CompletableFuture<T>) executor.execute(getDocumentRequest(key, options), type)
+                .exceptionally(handleGetDocumentExceptions(options != null ? options.isCatchException() : new DocumentReadOptions().isCatchException()));
+    }
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<T>> getDocuments(
-		final Collection<String> keys,
-		final Class<T> type) {
-		return getDocuments(keys, type, new DocumentReadOptions());
-	}
+    private <T> Function<Throwable, T> handleGetDocumentExceptions(Boolean isCatchException) {
+        return throwable -> {
+            ArangoDBException arangoDBException = null;
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<T>> getDocuments(
-		final Collection<String> keys,
-		final Class<T> type,
-		final DocumentReadOptions options) {
-		return executor.execute(getDocumentsRequest(keys, options), getDocumentsResponseDeserializer(type, options));
-	}
+            if (throwable instanceof ArangoDBException) {
+                arangoDBException = (ArangoDBException) throwable;
+            } else if (throwable instanceof CompletionException) {
+                CompletionException completionException = (CompletionException) throwable;
+                if (completionException.getCause() instanceof ArangoDBException) {
+                    arangoDBException = (ArangoDBException) completionException.getCause();
+                }
+            }
 
-	@Override
-	public <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(final String key, final T value) {
-		final DocumentReplaceOptions options = new DocumentReplaceOptions();
-		return executor.execute(replaceDocumentRequest(key, value, options),
-			replaceDocumentResponseDeserializer(value, options));
-	}
+            if (arangoDBException != null) {
+                if ((arangoDBException.getResponseCode() != null && (arangoDBException.getResponseCode() == 404 || arangoDBException.getResponseCode() == 304
+                        || arangoDBException.getResponseCode() == 412)) && isCatchException) {
+                    return null;
+                }
+            }
+            throw new CompletionException(throwable);
+        };
+    }
 
-	@Override
-	public <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(
-		final String key,
-		final T value,
-		final DocumentReplaceOptions options) {
-		return executor.execute(replaceDocumentRequest(key, value, options),
-			replaceDocumentResponseDeserializer(value, options));
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<T>> getDocuments(
+            final Collection<String> keys,
+            final Class<T> type) {
+        return getDocuments(keys, type, new DocumentReadOptions());
+    }
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(
-		final Collection<T> values) {
-		final DocumentReplaceOptions params = new DocumentReplaceOptions();
-		return executor.execute(replaceDocumentsRequest(values, params),
-			replaceDocumentsResponseDeserializer(values, params));
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<T>> getDocuments(
+            final Collection<String> keys,
+            final Class<T> type,
+            final DocumentReadOptions options) {
+        return executor.execute(getDocumentsRequest(keys, options), getDocumentsResponseDeserializer(type, options));
+    }
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(
-		final Collection<T> values,
-		final DocumentReplaceOptions options) {
-		final DocumentReplaceOptions params = (options != null ? options : new DocumentReplaceOptions());
-		return executor.execute(replaceDocumentsRequest(values, params),
-			replaceDocumentsResponseDeserializer(values, params));
-	}
+    @Override
+    public <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(final String key, final T value) {
+        final DocumentReplaceOptions options = new DocumentReplaceOptions();
+        return executor.execute(replaceDocumentRequest(key, value, options),
+                replaceDocumentResponseDeserializer(value, options));
+    }
 
-	@Override
-	public <T> CompletableFuture<DocumentUpdateEntity<T>> updateDocument(final String key, final T value) {
-		final DocumentUpdateOptions options = new DocumentUpdateOptions();
-		return executor.execute(updateDocumentRequest(key, value, options),
-			updateDocumentResponseDeserializer(value, options));
-	}
+    @Override
+    public <T> CompletableFuture<DocumentUpdateEntity<T>> replaceDocument(
+            final String key,
+            final T value,
+            final DocumentReplaceOptions options) {
+        return executor.execute(replaceDocumentRequest(key, value, options),
+                replaceDocumentResponseDeserializer(value, options));
+    }
 
-	@Override
-	public <T> CompletableFuture<DocumentUpdateEntity<T>> updateDocument(
-		final String key,
-		final T value,
-		final DocumentUpdateOptions options) {
-		return executor.execute(updateDocumentRequest(key, value, options),
-			updateDocumentResponseDeserializer(value, options));
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(
+            final Collection<T> values) {
+        final DocumentReplaceOptions params = new DocumentReplaceOptions();
+        return executor.execute(replaceDocumentsRequest(values, params),
+                replaceDocumentsResponseDeserializer(values, params));
+    }
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> updateDocuments(
-		final Collection<T> values) {
-		final DocumentUpdateOptions params = new DocumentUpdateOptions();
-		return executor.execute(updateDocumentsRequest(values, params),
-			updateDocumentsResponseDeserializer(values, params));
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> replaceDocuments(
+            final Collection<T> values,
+            final DocumentReplaceOptions options) {
+        final DocumentReplaceOptions params = (options != null ? options : new DocumentReplaceOptions());
+        return executor.execute(replaceDocumentsRequest(values, params),
+                replaceDocumentsResponseDeserializer(values, params));
+    }
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> updateDocuments(
-		final Collection<T> values,
-		final DocumentUpdateOptions options) {
-		final DocumentUpdateOptions params = (options != null ? options : new DocumentUpdateOptions());
-		return executor.execute(updateDocumentsRequest(values, params),
-			updateDocumentsResponseDeserializer(values, params));
-	}
+    @Override
+    public <T> CompletableFuture<DocumentUpdateEntity<T>> updateDocument(final String key, final T value) {
+        final DocumentUpdateOptions options = new DocumentUpdateOptions();
+        return executor.execute(updateDocumentRequest(key, value, options),
+                updateDocumentResponseDeserializer(value, options));
+    }
 
-	@Override
-	public CompletableFuture<DocumentDeleteEntity<Void>> deleteDocument(final String key) {
-		return executor.execute(deleteDocumentRequest(key, new DocumentDeleteOptions()),
-			deleteDocumentResponseDeserializer(Void.class));
-	}
+    @Override
+    public <T> CompletableFuture<DocumentUpdateEntity<T>> updateDocument(
+            final String key,
+            final T value,
+            final DocumentUpdateOptions options) {
+        return executor.execute(updateDocumentRequest(key, value, options),
+                updateDocumentResponseDeserializer(value, options));
+    }
 
-	@Override
-	public <T> CompletableFuture<DocumentDeleteEntity<T>> deleteDocument(
-		final String key,
-		final Class<T> type,
-		final DocumentDeleteOptions options) {
-		return executor.execute(deleteDocumentRequest(key, options), deleteDocumentResponseDeserializer(type));
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> updateDocuments(
+            final Collection<T> values) {
+        final DocumentUpdateOptions params = new DocumentUpdateOptions();
+        return executor.execute(updateDocumentsRequest(values, params),
+                updateDocumentsResponseDeserializer(values, params));
+    }
 
-	@Override
-	public CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<Void>>> deleteDocuments(
-		final Collection<?> values) {
-		return executor.execute(deleteDocumentsRequest(values, new DocumentDeleteOptions()),
-			deleteDocumentsResponseDeserializer(Void.class));
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentUpdateEntity<T>>> updateDocuments(
+            final Collection<T> values,
+            final DocumentUpdateOptions options) {
+        final DocumentUpdateOptions params = (options != null ? options : new DocumentUpdateOptions());
+        return executor.execute(updateDocumentsRequest(values, params),
+                updateDocumentsResponseDeserializer(values, params));
+    }
 
-	@Override
-	public <T> CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<T>>> deleteDocuments(
-		final Collection<?> values,
-		final Class<T> type,
-		final DocumentDeleteOptions options) {
-		return executor.execute(deleteDocumentsRequest(values, options), deleteDocumentsResponseDeserializer(type));
-	}
+    @Override
+    public CompletableFuture<DocumentDeleteEntity<Void>> deleteDocument(final String key) {
+        return executor.execute(deleteDocumentRequest(key, new DocumentDeleteOptions()),
+                deleteDocumentResponseDeserializer(Void.class));
+    }
 
-	@Override
-	public CompletableFuture<Boolean> documentExists(final String key) {
-		final CompletableFuture<Boolean> result = new CompletableFuture<>();
-		executor.execute(documentExistsRequest(key, new DocumentExistsOptions()), new ResponseDeserializer<Response>() {
-			@Override
-			public Response deserialize(final Response response) throws VPackException {
-				return response;
-			}
-		}).whenComplete(documentExistsResponseConsumer(result));
-		return result;
-	}
+    @Override
+    public <T> CompletableFuture<DocumentDeleteEntity<T>> deleteDocument(
+            final String key,
+            final Class<T> type,
+            final DocumentDeleteOptions options) {
+        return executor.execute(deleteDocumentRequest(key, options), deleteDocumentResponseDeserializer(type));
+    }
 
-	@Override
-	public CompletableFuture<Boolean> documentExists(final String key, final DocumentExistsOptions options) {
-		final CompletableFuture<Boolean> result = new CompletableFuture<>();
-		executor.execute(documentExistsRequest(key, options), new ResponseDeserializer<Response>() {
-			@Override
-			public Response deserialize(final Response response) throws VPackException {
-				return response;
-			}
-		}).whenComplete(documentExistsResponseConsumer(result));
-		return result;
-	}
+    @Override
+    public CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<Void>>> deleteDocuments(
+            final Collection<?> values) {
+        return executor.execute(deleteDocumentsRequest(values, new DocumentDeleteOptions()),
+                deleteDocumentsResponseDeserializer(Void.class));
+    }
 
-	private BiConsumer<? super Response, ? super Throwable> documentExistsResponseConsumer(
-		final CompletableFuture<Boolean> result) {
-		return (response, ex) -> {
-			if (response != null) {
-				result.complete(true);
-			} else if (ex != null) {
-				result.complete(false);
-			} else {
-				result.cancel(true);
-			}
-		};
-	}
+    @Override
+    public <T> CompletableFuture<MultiDocumentEntity<DocumentDeleteEntity<T>>> deleteDocuments(
+            final Collection<?> values,
+            final Class<T> type,
+            final DocumentDeleteOptions options) {
+        return executor.execute(deleteDocumentsRequest(values, options), deleteDocumentsResponseDeserializer(type));
+    }
 
-	@Override
-	public CompletableFuture<IndexEntity> getIndex(final String id) {
-		return executor.execute(getIndexRequest(id), IndexEntity.class);
-	}
+    @Override
+    public CompletableFuture<Boolean> documentExists(final String key) {
+        return documentExists(key, new DocumentExistsOptions());
+    }
 
-	@Override
-	public CompletableFuture<String> deleteIndex(final String id) {
-		return executor.execute(deleteIndexRequest(id), deleteIndexResponseDeserializer());
-	}
+    @Override
+    public CompletableFuture<Boolean> documentExists(final String key, final DocumentExistsOptions options) {
+        return executor.execute(documentExistsRequest(key, options), response -> response)
+                .exceptionally(handleGetDocumentExceptions(options != null ? options.isCatchException() : new DocumentExistsOptions().isCatchException()))
+                .thenApply(Objects::nonNull);
+    }
 
-	@Override
-	public CompletableFuture<IndexEntity> ensureHashIndex(
-		final Iterable<String> fields,
-		final HashIndexOptions options) {
-		return executor.execute(createHashIndexRequest(fields, options), IndexEntity.class);
-	}
+    @Override
+    public CompletableFuture<IndexEntity> getIndex(final String id) {
+        return executor.execute(getIndexRequest(id), IndexEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<IndexEntity> ensureSkiplistIndex(
-		final Iterable<String> fields,
-		final SkiplistIndexOptions options) {
-		return executor.execute(createSkiplistIndexRequest(fields, options), IndexEntity.class);
-	}
+    @Override
+    public CompletableFuture<String> deleteIndex(final String id) {
+        return executor.execute(deleteIndexRequest(id), deleteIndexResponseDeserializer());
+    }
 
-	@Override
-	public CompletableFuture<IndexEntity> ensurePersistentIndex(
-		final Iterable<String> fields,
-		final PersistentIndexOptions options) {
-		return executor.execute(createPersistentIndexRequest(fields, options), IndexEntity.class);
-	}
+    @Override
+    public CompletableFuture<IndexEntity> ensureHashIndex(
+            final Iterable<String> fields,
+            final HashIndexOptions options) {
+        return executor.execute(createHashIndexRequest(fields, options), IndexEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<IndexEntity> ensureGeoIndex(final Iterable<String> fields, final GeoIndexOptions options) {
-		return executor.execute(createGeoIndexRequest(fields, options), IndexEntity.class);
-	}
+    @Override
+    public CompletableFuture<IndexEntity> ensureSkiplistIndex(
+            final Iterable<String> fields,
+            final SkiplistIndexOptions options) {
+        return executor.execute(createSkiplistIndexRequest(fields, options), IndexEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<IndexEntity> ensureFulltextIndex(
-		final Iterable<String> fields,
-		final FulltextIndexOptions options) {
-		return executor.execute(createFulltextIndexRequest(fields, options), IndexEntity.class);
-	}
+    @Override
+    public CompletableFuture<IndexEntity> ensurePersistentIndex(
+            final Iterable<String> fields,
+            final PersistentIndexOptions options) {
+        return executor.execute(createPersistentIndexRequest(fields, options), IndexEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<Collection<IndexEntity>> getIndexes() {
-		return executor.execute(getIndexesRequest(), getIndexesResponseDeserializer());
-	}
+    @Override
+    public CompletableFuture<IndexEntity> ensureGeoIndex(final Iterable<String> fields, final GeoIndexOptions options) {
+        return executor.execute(createGeoIndexRequest(fields, options), IndexEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<Boolean> exists() {
-		return getInfo().thenApply(info -> info != null).exceptionally(e -> e == null);
-	}
+    @Override
+    public CompletableFuture<IndexEntity> ensureFulltextIndex(
+            final Iterable<String> fields,
+            final FulltextIndexOptions options) {
+        return executor.execute(createFulltextIndexRequest(fields, options), IndexEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<CollectionEntity> truncate() {
-		return executor.execute(truncateRequest(), CollectionEntity.class);
-	}
+    @Override
+    public CompletableFuture<Collection<IndexEntity>> getIndexes() {
+        return executor.execute(getIndexesRequest(), getIndexesResponseDeserializer());
+    }
 
-	@Override
-	public CompletableFuture<CollectionPropertiesEntity> count() {
-		return executor.execute(countRequest(), CollectionPropertiesEntity.class);
-	}
+    @Override
+    public CompletableFuture<Boolean> exists() {
+        return getInfo().thenApply(info -> info != null).exceptionally(e -> e == null);
+    }
 
-	@Override
-	public CompletableFuture<CollectionEntity> create() {
-		return db().createCollection(name());
-	}
+    @Override
+    public CompletableFuture<CollectionEntity> truncate() {
+        return executor.execute(truncateRequest(), CollectionEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<CollectionEntity> create(final CollectionCreateOptions options) {
-		return db().createCollection(name(), options);
-	}
+    @Override
+    public CompletableFuture<CollectionPropertiesEntity> count() {
+        return executor.execute(countRequest(), CollectionPropertiesEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<Void> drop() {
-		return executor.execute(dropRequest(null), Void.class);
-	}
+    @Override
+    public CompletableFuture<CollectionEntity> create() {
+        return db().createCollection(name());
+    }
 
-	@Override
-	public CompletableFuture<Void> drop(final boolean isSystem) {
-		return executor.execute(dropRequest(isSystem), Void.class);
-	}
+    @Override
+    public CompletableFuture<CollectionEntity> create(final CollectionCreateOptions options) {
+        return db().createCollection(name(), options);
+    }
 
-	@Override
-	public CompletableFuture<CollectionEntity> load() {
-		return executor.execute(loadRequest(), CollectionEntity.class);
-	}
+    @Override
+    public CompletableFuture<Void> drop() {
+        return executor.execute(dropRequest(null), Void.class);
+    }
 
-	@Override
-	public CompletableFuture<CollectionEntity> unload() {
-		return executor.execute(unloadRequest(), CollectionEntity.class);
-	}
+    @Override
+    public CompletableFuture<Void> drop(final boolean isSystem) {
+        return executor.execute(dropRequest(isSystem), Void.class);
+    }
 
-	@Override
-	public CompletableFuture<CollectionEntity> getInfo() {
-		return executor.execute(getInfoRequest(), CollectionEntity.class);
-	}
+    @Override
+    public CompletableFuture<CollectionEntity> load() {
+        return executor.execute(loadRequest(), CollectionEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<CollectionPropertiesEntity> getProperties() {
-		return executor.execute(getPropertiesRequest(), CollectionPropertiesEntity.class);
-	}
+    @Override
+    public CompletableFuture<CollectionEntity> unload() {
+        return executor.execute(unloadRequest(), CollectionEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<CollectionPropertiesEntity> changeProperties(final CollectionPropertiesOptions options) {
-		return executor.execute(changePropertiesRequest(options), CollectionPropertiesEntity.class);
-	}
+    @Override
+    public CompletableFuture<CollectionEntity> getInfo() {
+        return executor.execute(getInfoRequest(), CollectionEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<CollectionEntity> rename(final String newName) {
-		return executor.execute(renameRequest(newName), CollectionEntity.class);
-	}
+    @Override
+    public CompletableFuture<CollectionPropertiesEntity> getProperties() {
+        return executor.execute(getPropertiesRequest(), CollectionPropertiesEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<CollectionRevisionEntity> getRevision() {
-		return executor.execute(getRevisionRequest(), CollectionRevisionEntity.class);
-	}
+    @Override
+    public CompletableFuture<CollectionPropertiesEntity> changeProperties(final CollectionPropertiesOptions options) {
+        return executor.execute(changePropertiesRequest(options), CollectionPropertiesEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<Void> grantAccess(final String user, final Permissions permissions) {
-		return executor.execute(grantAccessRequest(user, permissions), Void.class);
-	}
+    @Override
+    public CompletableFuture<CollectionEntity> rename(final String newName) {
+        return executor.execute(renameRequest(newName), CollectionEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<Void> revokeAccess(final String user) {
-		return executor.execute(grantAccessRequest(user, Permissions.NONE), Void.class);
-	}
+    @Override
+    public CompletableFuture<CollectionRevisionEntity> getRevision() {
+        return executor.execute(getRevisionRequest(), CollectionRevisionEntity.class);
+    }
 
-	@Override
-	public CompletableFuture<Void> resetAccess(final String user) {
-		return executor.execute(resetAccessRequest(user), Void.class);
-	}
+    @Override
+    public CompletableFuture<Void> grantAccess(final String user, final Permissions permissions) {
+        return executor.execute(grantAccessRequest(user, permissions), Void.class);
+    }
 
-	@Override
-	public CompletableFuture<Permissions> getPermissions(final String user) {
-		return executor.execute(getPermissionsRequest(user), getPermissionsResponseDeserialzer());
-	}
+    @Override
+    public CompletableFuture<Void> revokeAccess(final String user) {
+        return executor.execute(grantAccessRequest(user, Permissions.NONE), Void.class);
+    }
+
+    @Override
+    public CompletableFuture<Void> resetAccess(final String user) {
+        return executor.execute(resetAccessRequest(user), Void.class);
+    }
+
+    @Override
+    public CompletableFuture<Permissions> getPermissions(final String user) {
+        return executor.execute(getPermissionsRequest(user), getPermissionsResponseDeserialzer());
+    }
 }

--- a/src/main/java/com/arangodb/internal/ArangoDBAsyncImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoDBAsyncImpl.java
@@ -166,14 +166,12 @@ public class ArangoDBAsyncImpl extends InternalArangoDB<ArangoExecutorAsync> imp
 	}
 
 	@Override
-	public CompletableFuture<Void> grantDefaultDatabaseAccess(final String user, final Permissions permissions)
-			throws ArangoDBException {
+	public CompletableFuture<Void> grantDefaultDatabaseAccess(final String user, final Permissions permissions) {
 		return executor.execute(updateUserDefaultDatabaseAccessRequest(user, permissions), Void.class);
 	}
 
 	@Override
-	public CompletableFuture<Void> grantDefaultCollectionAccess(final String user, final Permissions permissions)
-			throws ArangoDBException {
+	public CompletableFuture<Void> grantDefaultCollectionAccess(final String user, final Permissions permissions) {
 		return executor.execute(updateUserDefaultCollectionAccessRequest(user, permissions), Void.class);
 	}
 

--- a/src/main/java/com/arangodb/internal/ArangoDatabaseAsyncImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoDatabaseAsyncImpl.java
@@ -167,13 +167,12 @@ public class ArangoDatabaseAsyncImpl extends InternalArangoDatabase<ArangoDBAsyn
 	}
 
 	@Override
-	public CompletableFuture<Void> grantDefaultCollectionAccess(final String user, final Permissions permissions)
-			throws ArangoDBException {
+	public CompletableFuture<Void> grantDefaultCollectionAccess(final String user, final Permissions permissions) {
 		return executor.execute(updateUserDefaultCollectionAccessRequest(user, permissions), Void.class);
 	}
 
 	@Override
-	public CompletableFuture<Permissions> getPermissions(final String user) throws ArangoDBException {
+	public CompletableFuture<Permissions> getPermissions(final String user) {
 		return executor.execute(getPermissionsRequest(user), getPermissionsResponseDeserialzer());
 	}
 
@@ -182,20 +181,18 @@ public class ArangoDatabaseAsyncImpl extends InternalArangoDatabase<ArangoDBAsyn
 		final String query,
 		final Map<String, Object> bindVars,
 		final AqlQueryOptions options,
-		final Class<T> type) throws ArangoDBException {
+		final Class<T> type) {
 		final Request request = queryRequest(query, bindVars, options);
 		final HostHandle hostHandle = new HostHandle();
 		final CompletableFuture<CursorEntity> execution = executor.execute(request, CursorEntity.class, hostHandle);
-		return execution.thenApply(result -> {
-			return createCursor(result, type, options, hostHandle);
-		});
+		return execution.thenApply(result -> createCursor(result, type, options, hostHandle));
 	}
 
 	@Override
 	public <T> CompletableFuture<ArangoCursorAsync<T>> query(
 		final String query,
 		final AqlQueryOptions options,
-		final Class<T> type) throws ArangoDBException {
+		final Class<T> type) {
 		return query(query, null, options, type);
 	}
 
@@ -203,26 +200,20 @@ public class ArangoDatabaseAsyncImpl extends InternalArangoDatabase<ArangoDBAsyn
 	public <T> CompletableFuture<ArangoCursorAsync<T>> query(
 		final String query,
 		final Map<String, Object> bindVars,
-		final Class<T> type) throws ArangoDBException {
+		final Class<T> type) {
 		return query(query, bindVars, null, type);
 	}
 
 	@Override
-	public <T> CompletableFuture<ArangoCursorAsync<T>> query(final String query, final Class<T> type)
-			throws ArangoDBException {
+	public <T> CompletableFuture<ArangoCursorAsync<T>> query(final String query, final Class<T> type) {
 		return query(query, null, null, type);
 	}
 
 	@Override
-	public <T> CompletableFuture<ArangoCursorAsync<T>> cursor(final String cursorId, final Class<T> type) throws ArangoDBException {
-		
+	public <T> CompletableFuture<ArangoCursorAsync<T>> cursor(final String cursorId, final Class<T> type) {
 		final HostHandle hostHandle = new HostHandle();
-		
 		final CompletableFuture<CursorEntity> execution = executor.execute(queryNextRequest(cursorId, null, null), CursorEntity.class, hostHandle);
-		
-		return execution.thenApply(result -> {
-			return createCursor(result, type, null, hostHandle);
-		});
+		return execution.thenApply(result -> createCursor(result, type, null, hostHandle));
 	}
 
 	private <T> ArangoCursorAsync<T> createCursor(
@@ -408,7 +399,7 @@ public class ArangoDatabaseAsyncImpl extends InternalArangoDatabase<ArangoDBAsyn
 	}
 
 	@Override
-	public CompletableFuture<Collection<ViewEntity>> getViews() throws ArangoDBException {
+	public CompletableFuture<Collection<ViewEntity>> getViews() {
 		return executor.execute(getViewsRequest(), getViewsResponseDeserializer());
 	}
 
@@ -423,13 +414,12 @@ public class ArangoDatabaseAsyncImpl extends InternalArangoDatabase<ArangoDBAsyn
 	}
 
 	@Override
-	public CompletableFuture<ViewEntity> createView(final String name, final ViewType type) throws ArangoDBException {
+	public CompletableFuture<ViewEntity> createView(final String name, final ViewType type){
 		return executor.execute(createViewRequest(name, type), ViewEntity.class);
 	}
 
 	@Override
-	public CompletableFuture<ViewEntity> createArangoSearch(final String name, final ArangoSearchCreateOptions options)
-			throws ArangoDBException {
+	public CompletableFuture<ViewEntity> createArangoSearch(final String name, final ArangoSearchCreateOptions options) {
 		return executor.execute(createArangoSearchRequest(name, options), ViewEntity.class);
 	}
 

--- a/src/main/java/com/arangodb/internal/ArangoExecutorAsync.java
+++ b/src/main/java/com/arangodb/internal/ArangoExecutorAsync.java
@@ -75,7 +75,7 @@ public class ArangoExecutorAsync extends ArangoExecutor {
                                     } else if (response != null) {
                                         try {
                                             result.complete(responseDeserializer.deserialize(response));
-                                        } catch (final VPackException | ArangoDBException e) {
+                                        } catch (final VPackException e) {
                                             result.completeExceptionally(e);
                                         }
                                     }

--- a/src/main/java/com/arangodb/internal/ArangoExecutorAsync.java
+++ b/src/main/java/com/arangodb/internal/ArangoExecutorAsync.java
@@ -20,11 +20,9 @@
 
 package com.arangodb.internal;
 
-import com.arangodb.ArangoDBException;
 import com.arangodb.internal.net.HostHandle;
 import com.arangodb.internal.util.ArangoSerializationFactory;
 import com.arangodb.internal.velocystream.VstCommunicationAsync;
-import com.arangodb.velocypack.exception.VPackException;
 import com.arangodb.velocystream.Request;
 
 import java.io.IOException;
@@ -32,6 +30,7 @@ import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
 
 /**
  * @author Mark Vollmary
@@ -65,27 +64,9 @@ public class ArangoExecutorAsync extends ArangoExecutor {
             final ResponseDeserializer<T> responseDeserializer,
             final HostHandle hostHandle) {
 
-        CompletableFuture<T> result = new CompletableFuture<>();
-        outgoingExecutor.execute(() -> {
-                    try {
-                        communication.execute(request, hostHandle)
-                                .whenCompleteAsync((response, ex) -> {
-                                    if (ex != null) {
-                                        result.completeExceptionally(ex);
-                                    } else if (response != null) {
-                                        try {
-                                            result.complete(responseDeserializer.deserialize(response));
-                                        } catch (final VPackException e) {
-                                            result.completeExceptionally(e);
-                                        }
-                                    }
-                                });
-                    } catch (ArangoDBException e) {
-                        result.completeExceptionally(e);
-                    }
-                }
-        );
-        return result;
+        return CompletableFuture.supplyAsync(() -> communication.execute(request, hostHandle), outgoingExecutor)
+                .thenCompose(Function.identity())
+                .thenApplyAsync(responseDeserializer::deserialize);
     }
 
     public void disconnect() throws IOException {

--- a/src/main/java/com/arangodb/internal/ArangoSearchAsyncImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoSearchAsyncImpl.java
@@ -22,7 +22,6 @@ package com.arangodb.internal;
 
 import java.util.concurrent.CompletableFuture;
 
-import com.arangodb.ArangoDBException;
 import com.arangodb.ArangoSearchAsync;
 import com.arangodb.entity.ViewEntity;
 import com.arangodb.entity.arangosearch.ArangoSearchPropertiesEntity;
@@ -62,29 +61,28 @@ public class ArangoSearchAsyncImpl
 	}
 
 	@Override
-	public CompletableFuture<ViewEntity> create() throws ArangoDBException {
+	public CompletableFuture<ViewEntity> create() {
 		return create(new ArangoSearchCreateOptions());
 	}
 
 	@Override
-	public CompletableFuture<ViewEntity> create(final ArangoSearchCreateOptions options) throws ArangoDBException {
+	public CompletableFuture<ViewEntity> create(final ArangoSearchCreateOptions options) {
 		return db().createArangoSearch(name(), options);
 	}
 
 	@Override
-	public CompletableFuture<ArangoSearchPropertiesEntity> getProperties() throws ArangoDBException {
+	public CompletableFuture<ArangoSearchPropertiesEntity> getProperties() {
 		return executor.execute(getPropertiesRequest(), ArangoSearchPropertiesEntity.class);
 	}
 
 	@Override
-	public CompletableFuture<ArangoSearchPropertiesEntity> updateProperties(final ArangoSearchPropertiesOptions options)
-			throws ArangoDBException {
+	public CompletableFuture<ArangoSearchPropertiesEntity> updateProperties(final ArangoSearchPropertiesOptions options) {
 		return executor.execute(updatePropertiesRequest(options), ArangoSearchPropertiesEntity.class);
 	}
 
 	@Override
 	public CompletableFuture<ArangoSearchPropertiesEntity> replaceProperties(
-		final ArangoSearchPropertiesOptions options) throws ArangoDBException {
+		final ArangoSearchPropertiesOptions options) {
 		return executor.execute(replacePropertiesRequest(options), ArangoSearchPropertiesEntity.class);
 	}
 

--- a/src/main/java/com/arangodb/internal/ArangoVertexCollectionAsyncImpl.java
+++ b/src/main/java/com/arangodb/internal/ArangoVertexCollectionAsyncImpl.java
@@ -22,7 +22,6 @@ package com.arangodb.internal;
 
 import java.util.concurrent.CompletableFuture;
 
-import com.arangodb.ArangoDBException;
 import com.arangodb.ArangoVertexCollectionAsync;
 import com.arangodb.entity.VertexEntity;
 import com.arangodb.entity.VertexUpdateEntity;
@@ -88,8 +87,7 @@ public class ArangoVertexCollectionAsyncImpl extends
 	}
 
 	@Override
-	public <T> CompletableFuture<VertexUpdateEntity> updateVertex(final String key, final T value)
-			throws ArangoDBException {
+	public <T> CompletableFuture<VertexUpdateEntity> updateVertex(final String key, final T value) {
 		return executor.execute(updateVertexRequest(key, value, new VertexUpdateOptions()),
 			updateVertexResponseDeserializer(value));
 	}
@@ -98,7 +96,7 @@ public class ArangoVertexCollectionAsyncImpl extends
 	public <T> CompletableFuture<VertexUpdateEntity> updateVertex(
 		final String key,
 		final T value,
-		final VertexUpdateOptions options) throws ArangoDBException {
+		final VertexUpdateOptions options) {
 		return executor.execute(updateVertexRequest(key, value, options), updateVertexResponseDeserializer(value));
 	}
 

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunicationAsync.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunicationAsync.java
@@ -129,7 +129,7 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
 								rfuture.completeExceptionally(new ArangoDBException(errorEntity));
 							} else {
 								rfuture.completeExceptionally(new ArangoDBException(
-										String.format("Response Code: %s", response.getResponseCode())));
+										String.format("Response Code: %s", response.getResponseCode()), response.getResponseCode()));
 							}
 						} else {
 							rfuture.complete(response);

--- a/src/main/java/com/arangodb/internal/velocystream/VstCommunicationAsync.java
+++ b/src/main/java/com/arangodb/internal/velocystream/VstCommunicationAsync.java
@@ -20,15 +20,6 @@
 
 package com.arangodb.internal.velocystream;
 
-import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-
-import javax.net.ssl.SSLContext;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.arangodb.ArangoDBException;
 import com.arangodb.entity.ErrorEntity;
 import com.arangodb.internal.net.HostHandler;
@@ -39,6 +30,12 @@ import com.arangodb.velocypack.exception.VPackException;
 import com.arangodb.velocypack.exception.VPackParserException;
 import com.arangodb.velocystream.Request;
 import com.arangodb.velocystream.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 /**
  * @author Mark Vollmary
@@ -148,15 +145,14 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
 					rfuture.cancel(true);
 				}
 			});
-		} catch (final IOException | VPackException e) {
+		} catch (final VPackException e) {
 			LOGGER.error(e.getMessage(), e);
 			rfuture.completeExceptionally(e);
 		}
 		return rfuture;
 	}
 
-	private CompletableFuture<Message> send(final Message message, final VstConnectionAsync connection)
-			throws IOException {
+	private CompletableFuture<Message> send(final Message message, final VstConnectionAsync connection) {
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug(String.format("Send Message (id=%s, head=%s, body=%s)", message.getId(), message.getHead(),
 				message.getBody() != null ? message.getBody() : "{}"));
@@ -166,13 +162,11 @@ public class VstCommunicationAsync extends VstCommunication<CompletableFuture<Re
 
 	@Override
 	protected void authenticate(final VstConnectionAsync connection) {
-		Response response = null;
+		Response response;
 		try {
 			response = execute(new AuthenticationRequest(user, password != null ? password : "", ENCRYPTION_PLAIN),
 				connection).get();
-		} catch (final InterruptedException e) {
-			throw new ArangoDBException(e);
-		} catch (final ExecutionException e) {
+		} catch (final InterruptedException | ExecutionException e) {
 			throw new ArangoDBException(e);
 		}
 		checkError(response);

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -61,7 +61,7 @@ public class ArangoCollectionTest extends BaseTest {
             assertThat(result, is(notNullValue()));
             assertThat(result.getId(), is(notNullValue()));
         } finally {
-            db.collection(COLLECTION_NAME + "_1").drop();
+            db.collection(COLLECTION_NAME + "_1").drop().get();
         }
     }
 
@@ -1866,7 +1866,7 @@ public class ArangoCollectionTest extends BaseTest {
                     })
                     .get();
         } finally {
-            db.collection(collection).drop();
+            db.collection(collection).drop().get();
         }
     }
 

--- a/src/test/java/com/arangodb/ArangoCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoCollectionTest.java
@@ -211,8 +211,8 @@ public class ArangoCollectionTest extends BaseTest {
     }
 
     @Test(expected = ArangoDBException.class)
-    public void getDocumentWrongKey() throws InterruptedException, ExecutionException {
-        db.collection(COLLECTION_NAME).getDocument("no/no", BaseDocument.class).get();
+    public void getDocumentWrongKey() {
+        db.collection(COLLECTION_NAME).getDocument("no/no", BaseDocument.class);
     }
 
     @Test
@@ -251,7 +251,7 @@ public class ArangoCollectionTest extends BaseTest {
     }
 
     @Test
-    public void updateDocument() throws ArangoDBException, InterruptedException, ExecutionException {
+    public void updateDocument() throws InterruptedException, ExecutionException {
         final BaseDocument doc = new BaseDocument();
         doc.addAttribute("a", "test");
         doc.addAttribute("c", "test");
@@ -408,7 +408,7 @@ public class ArangoCollectionTest extends BaseTest {
     }
 
     @Test
-    public void updateDocumentKeepNullFalse() throws ArangoDBException, InterruptedException, ExecutionException {
+    public void updateDocumentKeepNullFalse() throws InterruptedException, ExecutionException {
         final BaseDocument doc = new BaseDocument();
         doc.addAttribute("a", "test");
         final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME).insertDocument(doc, null)
@@ -434,7 +434,7 @@ public class ArangoCollectionTest extends BaseTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void updateDocumentMergeObjectsTrue() throws ArangoDBException, InterruptedException, ExecutionException {
+    public void updateDocumentMergeObjectsTrue() throws InterruptedException, ExecutionException {
         final BaseDocument doc = new BaseDocument();
         final Map<String, String> a = new HashMap<>();
         a.put("a", "test");
@@ -466,7 +466,7 @@ public class ArangoCollectionTest extends BaseTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void updateDocumentMergeObjectsFalse() throws ArangoDBException, InterruptedException, ExecutionException {
+    public void updateDocumentMergeObjectsFalse() throws InterruptedException, ExecutionException {
         final BaseDocument doc = new BaseDocument();
         final Map<String, String> a = new HashMap<>();
         a.put("a", "test");
@@ -513,7 +513,7 @@ public class ArangoCollectionTest extends BaseTest {
     }
 
     @Test
-    public void replaceDocument() throws ArangoDBException, InterruptedException, ExecutionException {
+    public void replaceDocument() throws InterruptedException, ExecutionException {
         final BaseDocument doc = new BaseDocument();
         doc.addAttribute("a", "test");
         final DocumentCreateEntity<BaseDocument> createResult = db.collection(COLLECTION_NAME).insertDocument(doc, null)
@@ -1327,14 +1327,10 @@ public class ArangoCollectionTest extends BaseTest {
             assertThat(importResult.getCreated(), is(values.size()));
             for (int i = 0; i < keys.length; i++) {
                 BaseEdgeDocument doc;
-                try {
-                    doc = collection.getDocument(keys[i], BaseEdgeDocument.class).get();
-                    assertThat(doc, is(notNullValue()));
-                    assertThat(doc.getFrom(), is("foo/from"));
-                    assertThat(doc.getTo(), is("bar/to"));
-                } catch (ArangoDBException | InterruptedException | ExecutionException e) {
-                    fail();
-                }
+                doc = collection.getDocument(keys[i], BaseEdgeDocument.class).get();
+                assertThat(doc, is(notNullValue()));
+                assertThat(doc.getFrom(), is("foo/from"));
+                assertThat(doc.getTo(), is("bar/to"));
             }
         } finally {
             collection.drop().get();
@@ -1501,14 +1497,10 @@ public class ArangoCollectionTest extends BaseTest {
             assertThat(importResult.getCreated(), is(2));
             for (int i = 0; i < keys.length; i++) {
                 BaseEdgeDocument doc;
-                try {
-                    doc = collection.getDocument(keys[i], BaseEdgeDocument.class).get();
-                    assertThat(doc, is(notNullValue()));
-                    assertThat(doc.getFrom(), is("foo/from"));
-                    assertThat(doc.getTo(), is("bar/to"));
-                } catch (ArangoDBException | InterruptedException | ExecutionException e) {
-                    fail();
-                }
+                doc = collection.getDocument(keys[i], BaseEdgeDocument.class).get();
+                assertThat(doc, is(notNullValue()));
+                assertThat(doc.getFrom(), is("foo/from"));
+                assertThat(doc.getTo(), is("bar/to"));
             }
         } finally {
             collection.drop().get();
@@ -1979,7 +1971,7 @@ public class ArangoCollectionTest extends BaseTest {
     }
 
     @Test
-    public void getPermissions() throws ArangoDBException, InterruptedException, ExecutionException {
+    public void getPermissions() throws InterruptedException, ExecutionException {
         assertThat(Permissions.RW, is(db.collection(COLLECTION_NAME).getPermissions("root").get()));
     }
 }

--- a/src/test/java/com/arangodb/ArangoDBTest.java
+++ b/src/test/java/com/arangodb/ArangoDBTest.java
@@ -112,10 +112,7 @@ public class ArangoDBTest {
                     assertThat(result, is(true));
                 })
                 .get();
-        try {
-            arangoDB.db(BaseTest.TEST_DB).drop().get();
-        } catch (final ArangoDBException e) {
-        }
+        arangoDB.db(BaseTest.TEST_DB).drop().get();
     }
 
     @Test
@@ -351,7 +348,7 @@ public class ArangoDBTest {
     }
 
     @Test
-    public void authenticationFailPassword() throws InterruptedException, ExecutionException {
+    public void authenticationFailPassword() throws InterruptedException {
         final ArangoDBAsync arangoDB = new ArangoDBAsync.Builder().password("no").build();
         try {
             arangoDB.getVersion().get();
@@ -362,7 +359,7 @@ public class ArangoDBTest {
     }
 
     @Test
-    public void authenticationFailUser() throws InterruptedException, ExecutionException {
+    public void authenticationFailUser() throws InterruptedException {
         final ArangoDBAsync arangoDB = new ArangoDBAsync.Builder().user("no").build();
         try {
             arangoDB.getVersion().get();

--- a/src/test/java/com/arangodb/ArangoEdgeCollectionTest.java
+++ b/src/test/java/com/arangodb/ArangoEdgeCollectionTest.java
@@ -94,7 +94,7 @@ public class ArangoEdgeCollectionTest extends BaseTest {
 	}
 
 	@Test
-	public void insertEdge() throws ArangoDBException, InterruptedException, ExecutionException {
+	public void insertEdge() throws InterruptedException, ExecutionException {
 		final BaseEdgeDocument value = createEdgeValue();
 		final EdgeEntity edge = db.graph(GRAPH_NAME).edgeCollection(EDGE_COLLECTION_NAME).insertEdge(value, null).get();
 		assertThat(edge, is(notNullValue()));

--- a/src/test/java/com/arangodb/ArangoGraphTest.java
+++ b/src/test/java/com/arangodb/ArangoGraphTest.java
@@ -96,7 +96,7 @@ public class ArangoGraphTest extends BaseTest {
 			assertThat(result, is(notNullValue()));
 			assertThat(result.getName(), is(GRAPH_NAME + "_1"));
 		} finally {
-			db.graph(GRAPH_NAME + "_1").drop();
+			db.graph(GRAPH_NAME + "_1").drop().get();
 		}
 	}
 

--- a/src/test/java/com/arangodb/ArangoRouteTest.java
+++ b/src/test/java/com/arangodb/ArangoRouteTest.java
@@ -20,6 +20,7 @@
 
 package com.arangodb;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -75,9 +76,9 @@ public class ArangoRouteTest extends BaseTest {
 					.route(doc.getId()).get().get();
 			fail();
 		} catch (final ExecutionException e) {
-			assertThat(e.getCause() instanceof ArangoDBException, is(true));
+			assertThat(e.getCause(), instanceOf(ArangoDBException.class));
 		} finally {
-			collection.drop();
+			collection.drop().get();
 		}
 	}
 

--- a/src/test/java/com/arangodb/example/graph/BaseGraphTest.java
+++ b/src/test/java/com/arangodb/example/graph/BaseGraphTest.java
@@ -28,7 +28,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import com.arangodb.ArangoDBAsync;
-import com.arangodb.ArangoDBException;
 import com.arangodb.ArangoDatabaseAsync;
 import com.arangodb.entity.EdgeDefinition;
 import com.arangodb.entity.EdgeEntity;
@@ -78,7 +77,7 @@ public abstract class BaseGraphTest {
 		arangoDB = null;
 	}
 
-	private static void addExampleElements() throws ArangoDBException, InterruptedException, ExecutionException {
+	private static void addExampleElements() throws InterruptedException, ExecutionException {
 
 		// Add circle circles
 		final VertexEntity vA = createVertex(new Circle("A", "1"));
@@ -109,12 +108,12 @@ public abstract class BaseGraphTest {
 	}
 
 	private static EdgeEntity saveEdge(final CircleEdge edge)
-			throws ArangoDBException, InterruptedException, ExecutionException {
+			throws InterruptedException, ExecutionException {
 		return db.graph(GRAPH_NAME).edgeCollection(EDGE_COLLECTION_NAME).insertEdge(edge).get();
 	}
 
 	private static VertexEntity createVertex(final Circle vertex)
-			throws ArangoDBException, InterruptedException, ExecutionException {
+			throws InterruptedException, ExecutionException {
 		return db.graph(GRAPH_NAME).vertexCollection(VERTEXT_COLLECTION_NAME).insertVertex(vertex).get();
 	}
 

--- a/src/test/java/com/arangodb/example/graph/GraphTraversalsInAQLExample.java
+++ b/src/test/java/com/arangodb/example/graph/GraphTraversalsInAQLExample.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutionException;
 import org.junit.Test;
 
 import com.arangodb.ArangoCursorAsync;
-import com.arangodb.ArangoDBException;
 
 /**
  * Graph traversals in AQL
@@ -43,7 +42,7 @@ import com.arangodb.ArangoDBException;
 public class GraphTraversalsInAQLExample extends BaseGraphTest {
 
 	@Test
-	public void queryAllVertices() throws ArangoDBException, InterruptedException, ExecutionException {
+	public void queryAllVertices() throws InterruptedException, ExecutionException {
 		String queryString = "FOR v IN 1..3 OUTBOUND 'circles/A' GRAPH 'traversalGraph' RETURN v._key";
 		ArangoCursorAsync<String> cursor = db.query(queryString, null, null, String.class).get();
 		Collection<String> result = cursor.asListRemaining();
@@ -56,7 +55,7 @@ public class GraphTraversalsInAQLExample extends BaseGraphTest {
 	}
 
 	@Test
-	public void queryDepthTwo() throws ArangoDBException, InterruptedException, ExecutionException {
+	public void queryDepthTwo() throws InterruptedException, ExecutionException {
 		String queryString = "FOR v IN 2..2 OUTBOUND 'circles/A' GRAPH 'traversalGraph' return v._key";
 		ArangoCursorAsync<String> cursor = db.query(queryString, null, null, String.class).get();
 		Collection<String> result = cursor.asListRemaining();
@@ -71,7 +70,7 @@ public class GraphTraversalsInAQLExample extends BaseGraphTest {
 	}
 
 	@Test
-	public void queryWithFilter() throws ArangoDBException, InterruptedException, ExecutionException {
+	public void queryWithFilter() throws InterruptedException, ExecutionException {
 		String queryString = "FOR v, e, p IN 1..3 OUTBOUND 'circles/A' GRAPH 'traversalGraph' FILTER p.vertices[1]._key != 'G' RETURN v._key";
 		ArangoCursorAsync<String> cursor = db.query(queryString, null, null, String.class).get();
 		Collection<String> result = cursor.asListRemaining();
@@ -99,7 +98,7 @@ public class GraphTraversalsInAQLExample extends BaseGraphTest {
 	}
 
 	@Test
-	public void queryOutboundInbound() throws ArangoDBException, InterruptedException, ExecutionException {
+	public void queryOutboundInbound() throws InterruptedException, ExecutionException {
 		String queryString = "FOR v IN 1..3 OUTBOUND 'circles/E' GRAPH 'traversalGraph' return v._key";
 		ArangoCursorAsync<String> cursor = db.query(queryString, null, null, String.class).get();
 		Collection<String> result = cursor.asListRemaining();

--- a/src/test/java/com/arangodb/example/graph/ShortestPathInAQLExample.java
+++ b/src/test/java/com/arangodb/example/graph/ShortestPathInAQLExample.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutionException;
 import org.junit.Test;
 
 import com.arangodb.ArangoCursorAsync;
-import com.arangodb.ArangoDBException;
 
 /**
  * Shortest Path in AQL
@@ -68,7 +67,7 @@ public class ShortestPathInAQLExample extends BaseGraphTest {
 	}
 
 	@Test
-	public void queryShortestPathFromAToD() throws ArangoDBException, InterruptedException, ExecutionException {
+	public void queryShortestPathFromAToD() throws InterruptedException, ExecutionException {
 		String queryString = "FOR v, e IN OUTBOUND SHORTEST_PATH 'circles/A' TO 'circles/D' GRAPH 'traversalGraph' RETURN {'vertex': v._key, 'edge': e._key}";
 		ArangoCursorAsync<Pair> cursor = db.query(queryString, null, null, Pair.class).get();
 		final Collection<String> collection = toVertexCollection(cursor);
@@ -82,7 +81,7 @@ public class ShortestPathInAQLExample extends BaseGraphTest {
 	}
 
 	@Test
-	public void queryShortestPathByFilter() throws ArangoDBException, InterruptedException, ExecutionException {
+	public void queryShortestPathByFilter() throws InterruptedException, ExecutionException {
 		String queryString = "FOR a IN circles FILTER a._key == 'A' FOR d IN circles FILTER d._key == 'D' FOR v, e IN OUTBOUND SHORTEST_PATH a TO d GRAPH 'traversalGraph' RETURN {'vertex':v._key, 'edge':e._key}";
 		ArangoCursorAsync<Pair> cursor = db.query(queryString, null, null, Pair.class).get();
 		final Collection<String> collection = toVertexCollection(cursor);


### PR DESCRIPTION
The async driver should (ideally) never throw ArangoDBExceptions synchronously. I removed where possible all the occurrences of  `throws ArangoDBExceptions` from the async interfaces.
Where it has not been possible, it is because:
- of client side checks that happens before sending the actual request to the server (eg. when checking the correctness of document keys and ids)
- or blocking calls (eg. `ArangoCursorAsync::next()`), which should be refactored and made asynchronous